### PR TITLE
修复在有延时操作的情况下setLetters方法设置后的文字无法在竖直方向上居中的问题

### DIFF
--- a/quicksidebar/src/main/java/com/bigkoo/quicksidebar/QuickSideBarView.java
+++ b/quicksidebar/src/main/java/com/bigkoo/quicksidebar/QuickSideBarView.java
@@ -33,6 +33,8 @@ public class QuickSideBarView extends View {
     private int mHeight;
     private float mItemHeight;
     private float mItemStartY;
+    //计算位置
+    private Rect mRect = new Rect();
 
     public QuickSideBarView(Context context) {
         this(context, null);
@@ -69,6 +71,7 @@ public class QuickSideBarView extends View {
 
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
+        mItemStartY = (mHeight - mLetters.size()*mItemHeight)/2;
         for (int i = 0; i < mLetters.size(); i++) {
             mPaint.setColor(mTextColor);
 
@@ -81,12 +84,9 @@ public class QuickSideBarView extends View {
                 mPaint.setTextSize(mTextSizeChoose);
             }
 
-
-            //计算位置
-            Rect rect = new Rect();
-            mPaint.getTextBounds(mLetters.get(i), 0, mLetters.get(i).length(), rect);
-            float xPos = (int) ((mWidth - rect.width()) * 0.5);
-            float yPos = mItemHeight * i + (int) ((mItemHeight - rect.height()) * 0.5) + mItemStartY;
+            mPaint.getTextBounds(mLetters.get(i), 0, mLetters.get(i).length(), mRect);
+            float xPos = (int) ((mWidth - mRect.width()) * 0.5);
+            float yPos = mItemHeight * i + (int) ((mItemHeight - mRect.height()) * 0.5) + mItemStartY;
 
 
             canvas.drawText(mLetters.get(i), xPos, yPos, mPaint);
@@ -100,7 +100,6 @@ public class QuickSideBarView extends View {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
         mHeight = getMeasuredHeight();
         mWidth = getMeasuredWidth();
-        mItemStartY = (mHeight - mLetters.size()*mItemHeight)/2;
     }
 
     @Override


### PR DESCRIPTION
将 mItemStartY = (mHeight - mLetters.size()*mItemHeight)/2; 放在onDraw方法中，确保在更新时能重新计算位置